### PR TITLE
Ensure cache directory exists

### DIFF
--- a/src/main/java/de/julielab/ir/cache/LocalFileCacheAccess.java
+++ b/src/main/java/de/julielab/ir/cache/LocalFileCacheAccess.java
@@ -20,7 +20,15 @@ public class LocalFileCacheAccess<K, V> extends CacheAccess<K, V> {
         this.keySerializer = getSerializerByName(keySerializer);
         this.valueSerializer = getSerializerByName(valueSerializer);
         cacheService = CacheService.getInstance();
-        cacheFile = Path.of(TrecConfig.CACHE_DIR, cacheId).toFile();
+        cacheFile = new File(getCacheDir(), cacheId);
+    }
+
+    private File getCacheDir() {
+        final File cacheDir = new File(TrecConfig.CACHE_DIR);
+        if (!cacheDir.exists()) {
+            cacheDir.mkdirs();
+        }
+        return cacheDir;
     }
 
     @Override


### PR DESCRIPTION
This fixes the exception below when `OriginalDocumentRetrievalTest` is not skipped and `cache` has not been created.

```
Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 1.942 sec <<< FAILURE!
getSingleDocument(de.julielab.ir.OriginalDocumentRetrievalTest)  Time elapsed: 1.397 sec  <<< ERROR!
org.mapdb.DBException$VolumeIOError
	at org.mapdb.volume.MappedFileVol.<init>(MappedFileVol.java:113)
	at org.mapdb.volume.MappedFileVol$MappedFileFactory.factory(MappedFileVol.java:64)
	at org.mapdb.volume.MappedFileVol$MappedFileFactory.makeVolume(MappedFileVol.java:38)
	at org.mapdb.StoreWAL$realVolume$1.invoke(StoreWAL.kt:75)
	at org.mapdb.StoreWAL$realVolume$1.invoke(StoreWAL.kt:18)
	at org.mapdb.StoreWAL.<init>(StoreWAL.kt:74)
	at org.mapdb.StoreWAL$Companion.make(StoreWAL.kt:56)
	at org.mapdb.StoreWAL$Companion.make$default(StoreWAL.kt:55)
	at org.mapdb.DBMaker$Maker.make(DBMaker.kt:464)
	at de.julielab.ir.cache.CacheService.getFiledb(CacheService.java:85)
	at de.julielab.ir.cache.CacheService.getCache(CacheService.java:56)
	at de.julielab.ir.cache.LocalFileCacheAccess.get(LocalFileCacheAccess.java:28)
	at de.julielab.ir.OriginalDocumentRetrieval.lambda$setXmiCasDataToDocuments$7(OriginalDocumentRetrieval.java:234)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:176)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:177)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1654)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
	at de.julielab.ir.OriginalDocumentRetrieval.setXmiCasDataToDocuments(OriginalDocumentRetrieval.java:234)
	at de.julielab.ir.OriginalDocumentRetrievalTest.getSingleDocument(OriginalDocumentRetrievalTest.java:40)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:252)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:141)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:112)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:189)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:165)
	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:85)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:115)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:75)
Caused by: java.io.IOException: Parent folder does not exist: /home/travis/build/michelole/trec-pm/cache/uimaDocText.db
	at org.mapdb.volume.FileChannelVol.checkFolder(FileChannelVol.java:113)
	at org.mapdb.volume.MappedFileVol.<init>(MappedFileVol.java:84)
	... 51 more
```