### PR TITLE
Make `ExperimentsBuilder` singular

### DIFF
--- a/src/main/java/at/medunigraz/imi/bst/trec/BoostExperimenter.java
+++ b/src/main/java/at/medunigraz/imi/bst/trec/BoostExperimenter.java
@@ -1,26 +1,25 @@
 package at.medunigraz.imi.bst.trec;
 
 import at.medunigraz.imi.bst.trec.experiment.Experiment;
-import at.medunigraz.imi.bst.trec.experiment.ExperimentsBuilder;
+import at.medunigraz.imi.bst.trec.experiment.ExperimentBuilder;
 import at.medunigraz.imi.bst.trec.model.GoldStandard;
 import at.medunigraz.imi.bst.trec.model.Task;
 
 import java.io.File;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class BoostExperimenter {
 	public static void main(String[] args) {
 		final File relaxedTemplate = new File(RunnerDemo.class.getResource("/templates/biomedical_articles/boost.json").getFile());
 
-		ExperimentsBuilder builder = new ExperimentsBuilder();
+		Set<Experiment> experiments = new LinkedHashSet<>();
 
 		for (float i = 1; i <= 5; i += 0.5) {
-			builder.newExperiment().withYear(2017).withGoldStandard(GoldStandard.OFFICIAL)
+			experiments.add(new ExperimentBuilder().withYear(2017).withGoldStandard(GoldStandard.OFFICIAL)
 					.withTarget(Task.PUBMED).withProperties("keyword", String.valueOf(i)).withTemplate(relaxedTemplate)
-					.withWordRemoval();
+					.withWordRemoval().build());
 		}
-
-		Set<Experiment> experiments = builder.build();
 
 		for (Experiment exp : experiments) {
 			exp.start();

--- a/src/main/java/at/medunigraz/imi/bst/trec/ClinicalTrialsExperimenter.java
+++ b/src/main/java/at/medunigraz/imi/bst/trec/ClinicalTrialsExperimenter.java
@@ -1,11 +1,13 @@
 package at.medunigraz.imi.bst.trec;
 
 import at.medunigraz.imi.bst.trec.experiment.Experiment;
-import at.medunigraz.imi.bst.trec.experiment.ExperimentsBuilder;
+import at.medunigraz.imi.bst.trec.experiment.ExperimentBuilder;
 import at.medunigraz.imi.bst.trec.model.GoldStandard;
 import at.medunigraz.imi.bst.trec.model.Task;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class ClinicalTrialsExperimenter {
@@ -19,33 +21,31 @@ public class ClinicalTrialsExperimenter {
 		final Task target = Task.CLINICAL_TRIALS;
 		final int year = 2019;
 
-		ExperimentsBuilder builder = new ExperimentsBuilder();
-
 		// Judging order: 1
-		builder.newExperiment().withName("hpictall").withYear(year).withGoldStandard(goldStandard).withTarget(target)
+		Experiment hpictall = new ExperimentBuilder().withName("hpictall").withYear(year).withGoldStandard(goldStandard).withTarget(target)
                 .withSubTemplate(improvedTemplate).withWordRemoval().withSolidTumor().withDiseasePreferredTerm()
-                .withDiseaseSynonym().withGeneSynonym().withGeneDescription().withGeneFamily();
+                .withDiseaseSynonym().withGeneSynonym().withGeneDescription().withGeneFamily().build();
 
 		// Judging order: 2
-		builder.newExperiment().withName("hpictphrase").withYear(year).withGoldStandard(goldStandard).withTarget(target)
+		Experiment hpictphrase = new ExperimentBuilder().withName("hpictphrase").withYear(year).withGoldStandard(goldStandard).withTarget(target)
 				.withSubTemplate(phraseTemplate).withWordRemoval().withSolidTumor().withDiseasePreferredTerm()
-				.withDiseaseSynonym().withGeneSynonym().withGeneFamily();
+				.withDiseaseSynonym().withGeneSynonym().withGeneFamily().build();
 
 		// Judging order: 3
-		builder.newExperiment().withName("hpictboost").withYear(year).withGoldStandard(goldStandard).withTarget(target)
+		Experiment hpictboost = new ExperimentBuilder().withName("hpictboost").withYear(year).withGoldStandard(goldStandard).withTarget(target)
 				.withSubTemplate(improvedTemplate).withWordRemoval().withSolidTumor().withDiseasePreferredTerm()
-				.withDiseaseSynonym().withGeneSynonym().withGeneFamily();
+				.withDiseaseSynonym().withGeneSynonym().withGeneFamily().build();
 
 	  	// Judging order: 4
-	  	builder.newExperiment().withName("hpictcommon").withYear(year).withGoldStandard(goldStandard).withTarget(target)
+		Experiment hpictcommon = new ExperimentBuilder().withName("hpictcommon").withYear(year).withGoldStandard(goldStandard).withTarget(target)
 				.withSubTemplate(improvedTemplate).withWordRemoval().withDiseasePreferredTerm().withDiseaseSynonym()
-				.withGeneSynonym();
+				.withGeneSynonym().build();
 
 		// Judging order: 5
-		builder.newExperiment().withName("hpictbase").withYear(year).withGoldStandard(goldStandard).withTarget(target)
-				.withSubTemplate(improvedTemplate);
+		Experiment hpictbase = new ExperimentBuilder().withName("hpictbase").withYear(year).withGoldStandard(goldStandard).withTarget(target)
+				.withSubTemplate(improvedTemplate).build();
 
-		Set<Experiment> experiments = builder.build();
+		Set<Experiment> experiments = new LinkedHashSet<>(Arrays.asList(hpictall, hpictphrase, hpictboost, hpictcommon, hpictbase));
 
 		for (Experiment exp : experiments) {
 			exp.start();

--- a/src/main/java/at/medunigraz/imi/bst/trec/KeywordExperimenter.java
+++ b/src/main/java/at/medunigraz/imi/bst/trec/KeywordExperimenter.java
@@ -1,7 +1,7 @@
 package at.medunigraz.imi.bst.trec;
 
 import at.medunigraz.imi.bst.trec.experiment.Experiment;
-import at.medunigraz.imi.bst.trec.experiment.ExperimentsBuilder;
+import at.medunigraz.imi.bst.trec.experiment.ExperimentBuilder;
 import at.medunigraz.imi.bst.trec.model.GoldStandard;
 import at.medunigraz.imi.bst.trec.model.Task;
 import org.apache.commons.io.FileUtils;
@@ -16,8 +16,6 @@ public class KeywordExperimenter {
 				KeywordExperimenter.class.getResource("/templates/biomedical_articles/keyword.json").getFile());
 		final File keywordsSource = new File(KeywordExperimenter.class.getResource("/negative-keywords/").getFile());
 
-		ExperimentsBuilder builder = new ExperimentsBuilder();
-
 		File[] files = null;
 		if (keywordsSource.isDirectory()) {
 			files = keywordsSource.listFiles();
@@ -29,6 +27,7 @@ public class KeywordExperimenter {
 		double baselineMetric = 0;
 
 		// 1st step: collect metrics for individual keywords
+		Set<Experiment> experiments = new LinkedHashSet<>();
 
 		for (File keywordFile : files) {
 			List<String> lines;
@@ -40,18 +39,18 @@ public class KeywordExperimenter {
 			}
 
 			for (String keyword : lines) {
-				builder.newExperiment().withName(keyword).withYear(2017).withGoldStandard(GoldStandard.OFFICIAL)
+				experiments.add(new ExperimentBuilder().withName(keyword).withYear(2017).withGoldStandard(GoldStandard.OFFICIAL)
 						.withTarget(Task.PUBMED).withProperties("keyword", keyword).withTemplate(keywordTemplate)
-						.withWordRemoval();
+						.withWordRemoval().build());
 			}
 		}
 
-		TreeMap<Double, String> resultsUniqueKeywords = runExperiments(builder.build());
+		TreeMap<Double, String> resultsUniqueKeywords = runExperiments(experiments);
 
 
 
 		// 2nd step: collect metrics for combination of keywords in a greedy fashion
-		builder = new ExperimentsBuilder();
+		experiments = new LinkedHashSet<>();
 
 		String keyword = "";
 		for (Map.Entry<Double, String> entry : resultsUniqueKeywords.entrySet()) {
@@ -65,9 +64,9 @@ public class KeywordExperimenter {
 			keyword = keyword + " " + entry.getValue();
 			keyword = keyword.trim();
 
-			builder.newExperiment().withName(keyword).withYear(2017).withGoldStandard(GoldStandard.OFFICIAL)
+			experiments.add(new ExperimentBuilder().withName(keyword).withYear(2017).withGoldStandard(GoldStandard.OFFICIAL)
 					.withTarget(Task.PUBMED).withProperties("keyword", keyword).withTemplate(keywordTemplate)
-					.withWordRemoval();
+					.withWordRemoval().build());
 		}
 
 		//TreeMap<Double, String> resultsCombinationKeywords = runExperiments(builder.build());

--- a/src/main/java/at/medunigraz/imi/bst/trec/PubMedOnlineExperimenter.java
+++ b/src/main/java/at/medunigraz/imi/bst/trec/PubMedOnlineExperimenter.java
@@ -1,10 +1,12 @@
 package at.medunigraz.imi.bst.trec;
 
 import at.medunigraz.imi.bst.trec.experiment.Experiment;
-import at.medunigraz.imi.bst.trec.experiment.ExperimentsBuilder;
+import at.medunigraz.imi.bst.trec.experiment.ExperimentBuilder;
 import at.medunigraz.imi.bst.trec.model.GoldStandard;
 import at.medunigraz.imi.bst.trec.model.Task;
 
+import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class PubMedOnlineExperimenter {
@@ -13,16 +15,12 @@ public class PubMedOnlineExperimenter {
         final Task target = Task.PUBMED_ONLINE;
         final int year = 2017;
 
-
-        ExperimentsBuilder builder = new ExperimentsBuilder();
-
-
-        builder.newExperiment().withName("pmonlinetest").withYear(year).withGoldStandard(goldStandard).withTarget(target)
+        Experiment pmonlinetest = new ExperimentBuilder().withName("pmonlinetest").withYear(year).withGoldStandard(goldStandard).withTarget(target)
               .withWordRemoval().withGeneSynonym().
-               withGeneDescription();
+               withGeneDescription().build();
 
 
-        Set<Experiment> experiments = builder.build();
+        Set<Experiment> experiments = new LinkedHashSet<>(Arrays.asList(pmonlinetest));
 
         for (Experiment exp : experiments) {
             exp.start();

--- a/src/main/java/at/medunigraz/imi/bst/trec/PubmedExperimenter.java
+++ b/src/main/java/at/medunigraz/imi/bst/trec/PubmedExperimenter.java
@@ -1,11 +1,13 @@
 package at.medunigraz.imi.bst.trec;
 
 import at.medunigraz.imi.bst.trec.experiment.Experiment;
-import at.medunigraz.imi.bst.trec.experiment.ExperimentsBuilder;
+import at.medunigraz.imi.bst.trec.experiment.ExperimentBuilder;
 import at.medunigraz.imi.bst.trec.model.GoldStandard;
 import at.medunigraz.imi.bst.trec.model.Task;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class PubmedExperimenter {
@@ -21,35 +23,31 @@ public class PubmedExperimenter {
 		final Task target = Task.PUBMED;
 		final int year = 2017;
 
-
-		ExperimentsBuilder builder = new ExperimentsBuilder();
-
-
 		// Judging order: 1
-		builder.newExperiment().withName("hpipubclass").withYear(year).withGoldStandard(goldStandard).withTarget(target)
+		Experiment hpipubclass = new ExperimentBuilder().withName("hpipubclass").withYear(year).withGoldStandard(goldStandard).withTarget(target)
 				.withSubTemplate(extraBoostTemplate).withWordRemoval().withGeneSynonym()
-				.withDiseasePreferredTerm().withGeneDescription().withDiseaseSynonym();
+				.withDiseasePreferredTerm().withGeneDescription().withDiseaseSynonym().build();
 
 		// Judging order: 2
-		builder.newExperiment().withName("hpipubnone").withYear(year).withGoldStandard(goldStandard).withTarget(target)
+		Experiment hpipubnone = new ExperimentBuilder().withName("hpipubnone").withYear(year).withGoldStandard(goldStandard).withTarget(target)
 				.withSubTemplate(noClassifierTemplate).withWordRemoval().withGeneSynonym()
-                		.withDiseasePreferredTerm().withGeneDescription().withDiseaseSynonym();
+                		.withDiseasePreferredTerm().withGeneDescription().withDiseaseSynonym().build();
 
 		// Judging order: 3
-		builder.newExperiment().withName("hpipubboost").withYear(year).withGoldStandard(goldStandard).withTarget(target)
+		Experiment hpipubboost = new ExperimentBuilder().withName("hpipubboost").withYear(year).withGoldStandard(goldStandard).withTarget(target)
 				.withSubTemplate(improvedTemplate).withWordRemoval().withGeneSynonym()
-                		.withDiseasePreferredTerm().withGeneDescription().withDiseaseSynonym();
+                		.withDiseasePreferredTerm().withGeneDescription().withDiseaseSynonym().build();
 
 		// Judging order: 4
-		builder.newExperiment().withName("hpipubcommon").withYear(year).withGoldStandard(goldStandard).withTarget(target)
+		Experiment hpipubcommon = new ExperimentBuilder().withName("hpipubcommon").withYear(year).withGoldStandard(goldStandard).withTarget(target)
 				.withSubTemplate(noClassifierTemplate).withWordRemoval().withGeneSynonym()
-				.withDiseasePreferredTerm().withDiseaseSynonym();
+				.withDiseasePreferredTerm().withDiseaseSynonym().build();
 
 		// Judging order: 5
-		builder.newExperiment().withName("hpipubbase").withYear(year).withGoldStandard(goldStandard).withTarget(target)
-				.withSubTemplate(noClassifierTemplate);
+		Experiment hpipubbase = new ExperimentBuilder().withName("hpipubbase").withYear(year).withGoldStandard(goldStandard).withTarget(target)
+				.withSubTemplate(noClassifierTemplate).build();
 
-		Set<Experiment> experiments = builder.build();
+		Set<Experiment> experiments = new LinkedHashSet<>(Arrays.asList(hpipubclass, hpipubnone, hpipubboost, hpipubcommon, hpipubbase));
 
 		for (Experiment exp : experiments) {
 			exp.start();

--- a/src/main/java/at/medunigraz/imi/bst/trec/RunnerDemo.java
+++ b/src/main/java/at/medunigraz/imi/bst/trec/RunnerDemo.java
@@ -1,11 +1,13 @@
 package at.medunigraz.imi.bst.trec;
 
 import at.medunigraz.imi.bst.trec.experiment.Experiment;
-import at.medunigraz.imi.bst.trec.experiment.ExperimentsBuilder;
+import at.medunigraz.imi.bst.trec.experiment.ExperimentBuilder;
 import at.medunigraz.imi.bst.trec.model.GoldStandard;
 import at.medunigraz.imi.bst.trec.model.Task;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class RunnerDemo {
@@ -16,14 +18,12 @@ public class RunnerDemo {
 		final int year = 2017;
 
 
-		ExperimentsBuilder builder = new ExperimentsBuilder();
+		Experiment ba = new ExperimentBuilder().withYear(year).withGoldStandard(GoldStandard.OFFICIAL).withTarget(Task.PUBMED)
+				.withSubTemplate(pmTemplate).withWordRemoval().build();
+		Experiment ct = new ExperimentBuilder().withYear(year).withGoldStandard(GoldStandard.OFFICIAL)
+				.withTarget(Task.CLINICAL_TRIALS).withSubTemplate(ctTemplate).withWordRemoval().build();
 
-		builder.newExperiment().withYear(year).withGoldStandard(GoldStandard.OFFICIAL).withTarget(Task.PUBMED)
-				.withSubTemplate(pmTemplate).withWordRemoval();
-		builder.newExperiment().withYear(year).withGoldStandard(GoldStandard.OFFICIAL)
-				.withTarget(Task.CLINICAL_TRIALS).withSubTemplate(ctTemplate).withWordRemoval();
-
-		Set<Experiment> bestExperiments = builder.build();
+		Set<Experiment> bestExperiments = new LinkedHashSet<>(Arrays.asList(ba, ct));
 
 		for (Experiment exp : bestExperiments) {
 			exp.start();

--- a/src/main/java/at/medunigraz/imi/bst/trec/experiment/ExperimentBuilder.java
+++ b/src/main/java/at/medunigraz/imi/bst/trec/experiment/ExperimentBuilder.java
@@ -8,51 +8,34 @@ import at.medunigraz.imi.bst.trec.model.GoldStandard;
 import at.medunigraz.imi.bst.trec.model.Task;
 
 import java.io.File;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
-public class ExperimentsBuilder {
+public class ExperimentBuilder {
 
-    private Set<Experiment> experiments = new HashSet<>();
+    private Experiment buildingExp = new Experiment();
+    private TrecPmRetrieval retrieval = new TrecPmRetrieval();
 
-    private Experiment buildingExp = null;
-    private String statsDir;
-    private String resultsDir;
-    private TrecPmRetrieval retrieval;
-
-    public ExperimentsBuilder() {
-    }
-
-    public ExperimentsBuilder newExperiment() {
-        validate();
-        buildingExp = new Experiment();
-        retrieval = new TrecPmRetrieval();
+    public ExperimentBuilder() {
         buildingExp.setRetrieval(retrieval);
-        if (statsDir != null)
-            withStatsDir(statsDir);
-        if (resultsDir != null)
-            withResultsDir(resultsDir);
-        return this;
     }
 
-    public ExperimentsBuilder withName(String name) {
+    public ExperimentBuilder withName(String name) {
         retrieval.withExperimentName(name);
         return this;
     }
 
-    public ExperimentsBuilder withDecorator(Query decorator) {
+    public ExperimentBuilder withDecorator(Query decorator) {
         retrieval.setQuery(decorator);
         return this;
     }
 
-    public ExperimentsBuilder withTemplate(File template) {
+    public ExperimentBuilder withTemplate(File template) {
         retrieval.withTemplate(template);
         return this;
     }
 
 
-    public ExperimentsBuilder withSubTemplate(File template) {
+    public ExperimentBuilder withSubTemplate(File template) {
         retrieval.withSubTemplate(template);
         return this;
     }
@@ -63,9 +46,9 @@ public class ExperimentsBuilder {
      * </p>
      *
      * @param templateProperties A map holding the poperties from the template and the values they should be replaced with.
-     * @return This ExperimentsBuilder.
+     * @return This ExperimentBuilder.
      */
-    public ExperimentsBuilder withProperties(Map<String, String> templateProperties) {
+    public ExperimentBuilder withProperties(Map<String, String> templateProperties) {
         retrieval.withProperties(templateProperties);
         return this;
     }
@@ -77,84 +60,84 @@ public class ExperimentsBuilder {
      * <p>The parameters of the method are property-value pairs were the property always comes first and then the associated value.</p>
      *
      * @param templatePropertiesAndValues An array holding the poperties from the template and the values they should be replaced with.
-     * @return This ExperimentsBuilder.
+     * @return This ExperimentBuilder.
      */
-    public ExperimentsBuilder withProperties(String... templatePropertiesAndValues) {
+    public ExperimentBuilder withProperties(String... templatePropertiesAndValues) {
         retrieval.withProperties(templatePropertiesAndValues);
         return this;
     }
 
-    public ExperimentsBuilder withWordRemoval() {
+    public ExperimentBuilder withWordRemoval() {
         retrieval.withWordRemoval();
         return this;
     }
 
-    public ExperimentsBuilder withGeneExpansion(Gene.Field[] expandTo) {
+    public ExperimentBuilder withGeneExpansion(Gene.Field[] expandTo) {
         retrieval.withGeneExpansion(expandTo);
         return this;
     }
 
-    public ExperimentsBuilder withDiseaseReplacer() {
+    public ExperimentBuilder withDiseaseReplacer() {
         retrieval.withDiseaseReplacer();
         return this;
     }
 
-    public ExperimentsBuilder withDiseaseExpander() {
+    public ExperimentBuilder withDiseaseExpander() {
         retrieval.withDiseaseExpander();
         return this;
     }
 
-    public ExperimentsBuilder withDiseasePreferredTerm() {
+    public ExperimentBuilder withDiseasePreferredTerm() {
         retrieval.withDiseasePreferredTerm();
         return this;
     }
 
-    public ExperimentsBuilder withDiseaseSynonym() {
+    public ExperimentBuilder withDiseaseSynonym() {
         retrieval.withDiseaseSynonym();
         return this;
     }
 
-    public ExperimentsBuilder withResistantDrugs() {
+    public ExperimentBuilder withResistantDrugs() {
         retrieval.withResistantDrugs();
         return this;
     }
 
-    public ExperimentsBuilder withGeneSynonym() {
+    public ExperimentBuilder withGeneSynonym() {
         retrieval.withGeneSynonym();
         return this;
     }
 
-    public ExperimentsBuilder withGeneDescription() {
+    public ExperimentBuilder withGeneDescription() {
         retrieval.withGeneDescription();
         return this;
     }
 
-    public ExperimentsBuilder withDiseaseHypernym() {
+    public ExperimentBuilder withDiseaseHypernym() {
         retrieval.withDiseaseHypernym();
         return this;
     }
 
-    public ExperimentsBuilder withSolidTumor() {
+    public ExperimentBuilder withSolidTumor() {
         retrieval.withSolidTumor();
         return this;
     }
 
-    public ExperimentsBuilder withGeneFamily() {
+    public ExperimentBuilder withGeneFamily() {
         retrieval.withGeneFamily();
         return this;
     }
 
-    public ExperimentsBuilder withDrugInteraction() {
+    public ExperimentBuilder withDrugInteraction() {
         retrieval.withDrugInteraction();
         return this;
     }
 
-    public ExperimentsBuilder withGoldStandard(GoldStandard gold) {
+    public ExperimentBuilder withGoldStandard(GoldStandard gold) {
         buildingExp.setGoldStandard(gold);
         return this;
     }
 
-    public ExperimentsBuilder withTarget(Task task) {
+    public ExperimentBuilder withTarget(Task task) {
         buildingExp.setTask(task);
         if (task != Task.PUBMED_ONLINE)
             retrieval.setQuery(new ElasticSearchQuery(buildingExp.getGoldStandard()));
@@ -163,42 +146,22 @@ public class ExperimentsBuilder {
         return this;
     }
 
-    public ExperimentsBuilder withYear(int year) {
+    public ExperimentBuilder withYear(int year) {
         buildingExp.setYear(year);
         return this;
     }
 
-    public ExperimentsBuilder withStatsDir(String dir) {
+    public ExperimentBuilder withStatsDir(String dir) {
         buildingExp.setStatsDir(dir);
         return this;
     }
 
-    public ExperimentsBuilder withResultsDir(String dir) {
+    public ExperimentBuilder withResultsDir(String dir) {
         buildingExp.setResultsDir(dir);
         return this;
     }
 
-    public Set<Experiment> build() {
-        validate();
-        return experiments;
-    }
-
-    public Experiment getCurrentExperiment() {
+    public Experiment build() {
         return buildingExp;
-    }
-
-    private void validate() {
-        if (buildingExp != null) {
-            this.experiments.add(buildingExp);
-            return;
-        }
-    }
-
-    public void setDefaultStatsDir(String statsDir) {
-        this.statsDir = statsDir;
-    }
-
-    public void setDefaultResultsDir(String resultsDir) {
-        this.resultsDir = resultsDir;
     }
 }


### PR DESCRIPTION
This makes `ExperimentBuilder` behavior more predictable and its code much simpler, as it now handles the creation of a single experiment each time.

This removes unused `setDefaultResultsDir` and `setDefaultStatsDir` methods, which would be incompatible with an immutable builder.

This fixes #6.