### PR TITLE
Make `Topic` do not depend on `Task`

### DIFF
--- a/src/main/java/at/medunigraz/imi/bst/lexigram/Lexigram.java
+++ b/src/main/java/at/medunigraz/imi/bst/lexigram/Lexigram.java
@@ -3,7 +3,6 @@ package at.medunigraz.imi.bst.lexigram;
 import at.medunigraz.imi.bst.config.TrecConfig;
 import at.medunigraz.imi.bst.trec.expansion.CachedWebRequester;
 import at.medunigraz.imi.bst.trec.model.Challenge;
-import at.medunigraz.imi.bst.trec.model.Task;
 import at.medunigraz.imi.bst.trec.model.Topic;
 import at.medunigraz.imi.bst.trec.model.TopicSet;
 import at.medunigraz.imi.bst.trec.stats.CSVStatsWriter;
@@ -209,7 +208,7 @@ public class Lexigram {
     public static void main(String[] args) {
         final File topicsFile = new File(CSVStatsWriter.class.getResource("/topics/topics2018.xml").getPath());
 
-        TopicSet topicSet = new TopicSet(topicsFile, Challenge.TREC_PM, Task.PUBMED, 2018);
+        TopicSet topicSet = new TopicSet(topicsFile, Challenge.TREC_PM, 2018);
         JSONObject output = createDump(topicSet);
 
         System.out.println(JsonUtils.prettify(output));

--- a/src/main/java/at/medunigraz/imi/bst/retrieval/ElasticSearchQuery.java
+++ b/src/main/java/at/medunigraz/imi/bst/retrieval/ElasticSearchQuery.java
@@ -1,7 +1,6 @@
 package at.medunigraz.imi.bst.retrieval;
 
 import at.medunigraz.imi.bst.config.TrecConfig;
-import at.medunigraz.imi.bst.trec.model.GoldStandard;
 import at.medunigraz.imi.bst.trec.model.Result;
 import at.medunigraz.imi.bst.trec.search.ElasticSearch;
 import de.julielab.ir.es.SimilarityParameters;
@@ -12,7 +11,6 @@ import java.util.List;
 
 public class ElasticSearchQuery<T extends QueryDescription> implements Query<T> {
 
-    private GoldStandard goldStandard;
     private String jsonQuery;
 
     private String[] types = null;
@@ -21,15 +19,6 @@ public class ElasticSearchQuery<T extends QueryDescription> implements Query<T> 
     private SimilarityParameters parameters;
 
     private int size = TrecConfig.SIZE;
-
-    public ElasticSearchQuery(int size, GoldStandard goldStandard) {
-        this.size = size;
-        this.goldStandard = goldStandard;
-    }
-
-    public ElasticSearchQuery(GoldStandard goldStandard) {
-        this.goldStandard = goldStandard;
-    }
 
     public ElasticSearchQuery(int size, String index, String... types) {
         this.size = size;
@@ -45,11 +34,10 @@ public class ElasticSearchQuery<T extends QueryDescription> implements Query<T> 
     @Override
     public List<Result> query(T topic) {
         ElasticSearch es;
-        final String index = this.index != null ? this.index : Retrieval.getIndexName(topic.getTask());
         if (this.types != null) {
-            es = new ElasticSearch(index, parameters, this.types);
+            es = new ElasticSearch(this.index, parameters, this.types);
         } else {
-            es = new ElasticSearch(index, parameters);
+            es = new ElasticSearch(this.index, parameters);
         }
         return es.query(new JSONObject(jsonQuery), size);
     }

--- a/src/main/java/at/medunigraz/imi/bst/retrieval/Retrieval.java
+++ b/src/main/java/at/medunigraz/imi/bst/retrieval/Retrieval.java
@@ -113,7 +113,7 @@ public class Retrieval<T extends Retrieval, Q extends QueryDescription> {
     public T withTarget(Task task) {
         this.task = task;
         if (task != Task.PUBMED_ONLINE)
-            query = new ElasticSearchQuery(size, goldStandard);
+            query = new ElasticSearchQuery(size, getIndexName(task));
         else
             query = new PubMedOnlineQuery();
         return (T) this;

--- a/src/main/java/at/medunigraz/imi/bst/trec/experiment/Experiment.java
+++ b/src/main/java/at/medunigraz/imi/bst/trec/experiment/Experiment.java
@@ -142,7 +142,7 @@ public class Experiment<Q extends QueryDescription> extends Thread {
     @NotNull
     private TopicSet loadTopics() {
         File example = new File(CSVStatsWriter.class.getResource("/topics/topics" + year + ".xml").getPath());
-        return new TopicSet(example, challenge, task, year);
+        return new TopicSet(example, challenge, year);
     }
 
     public void setYear(int year) {

--- a/src/main/java/at/medunigraz/imi/bst/trec/experiment/ExperimentBuilder.java
+++ b/src/main/java/at/medunigraz/imi/bst/trec/experiment/ExperimentBuilder.java
@@ -1,7 +1,5 @@
 package at.medunigraz.imi.bst.trec.experiment;
 
-import at.medunigraz.imi.bst.retrieval.ElasticSearchQuery;
-import at.medunigraz.imi.bst.retrieval.PubMedOnlineQuery;
 import at.medunigraz.imi.bst.retrieval.Query;
 import at.medunigraz.imi.bst.trec.model.Gene;
 import at.medunigraz.imi.bst.trec.model.GoldStandard;
@@ -139,10 +137,7 @@ public class ExperimentBuilder {
 
     public ExperimentBuilder withTarget(Task task) {
         buildingExp.setTask(task);
-        if (task != Task.PUBMED_ONLINE)
-            retrieval.setQuery(new ElasticSearchQuery(buildingExp.getGoldStandard()));
-        else
-            retrieval.setQuery(new PubMedOnlineQuery());
+        retrieval.withTarget(task);
         return this;
     }
 

--- a/src/main/java/at/medunigraz/imi/bst/trec/model/Topic.java
+++ b/src/main/java/at/medunigraz/imi/bst/trec/model/Topic.java
@@ -149,11 +149,6 @@ public class Topic extends QueryDescription {
         return this;
     }
 
-    public Topic withTask(Task task) {
-        setTask(task);
-        return this;
-    }
-
     public Topic withYear(int year) {
         setYear(year);
         return this;

--- a/src/main/java/at/medunigraz/imi/bst/trec/model/TopicSet.java
+++ b/src/main/java/at/medunigraz/imi/bst/trec/model/TopicSet.java
@@ -21,7 +21,7 @@ public class TopicSet {
 		this.topics = new ArrayList<>(topics);
 	}
 
-	public TopicSet(File xmlFile, Challenge challenge, Task task, int year) {
+	public TopicSet(File xmlFile, Challenge challenge, int year) {
 		DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
 
 		Document doc;
@@ -39,7 +39,6 @@ public class TopicSet {
 			Element element = (Element) xmlTopics.item(i);
 			Topic t = Topic.fromElement(element);
 			t.setChallenge(challenge);
-			t.setTask(task);
 			t.setYear(year);
 			topics.add(t);
 		}

--- a/src/main/java/de/julielab/ir/evaluation/GoogleSheetsSyncer.java
+++ b/src/main/java/de/julielab/ir/evaluation/GoogleSheetsSyncer.java
@@ -43,7 +43,7 @@ public class GoogleSheetsSyncer {
     }
 
     private static GoogleSheetsGoldStandard<Topic> download(Task task) {
-        List<Topic> topics = new TopicSet(TOPICS, CHALLENGE, task, YEAR).getTopics();
+        List<Topic> topics = new TopicSet(TOPICS, CHALLENGE, YEAR).getTopics();
 
         // TODO Move to GoldStandardBuilder (#17)
         String[] readRange = null;

--- a/src/main/java/de/julielab/ir/evaluation/TrecPM1718LitCrossval.java
+++ b/src/main/java/de/julielab/ir/evaluation/TrecPM1718LitCrossval.java
@@ -53,9 +53,9 @@ public class TrecPM1718LitCrossval {
 
 
         File topicsFile2017 = new File(CSVStatsWriter.class.getResource("/topics/topics2017.xml").getPath());
-        final TopicSet topics2017 = new TopicSet(topicsFile2017, Challenge.TREC_PM, Task.PUBMED, 2017);
+        final TopicSet topics2017 = new TopicSet(topicsFile2017, Challenge.TREC_PM, 2017);
         File topicsFile2018 = new File(CSVStatsWriter.class.getResource("/topics/topics2018.xml").getPath());
-        final TopicSet topics2018 = new TopicSet(topicsFile2018, Challenge.TREC_PM, Task.PUBMED, 2018);
+        final TopicSet topics2018 = new TopicSet(topicsFile2018, Challenge.TREC_PM, 2018);
 
         final TrecQrelGoldStandard<Topic> trecPmLit2017 = new TrecQrelGoldStandard<>(Challenge.TREC_PM, Task.PUBMED, 2017, topics2017.getTopics(), Path.of("src", "main", "resources", "gold-standard", "qrels-treceval-abstracts.2017.txt").toFile(), Path.of("src", "main", "resources", "gold-standard", "sample-qrels-final-abstracts.2017.txt").toFile());
         final TrecQrelGoldStandard<Topic> trecPmLit2018 = new TrecQrelGoldStandard<>(Challenge.TREC_PM, Task.PUBMED, 2018, topics2018.getTopics(), Path.of("src", "main", "resources", "gold-standard", "qrels-treceval-abstracts.2018.txt").toFile(), Path.of("src", "main", "resources", "gold-standard", "qrels-sample-abstracts.2018.txt").toFile());

--- a/src/main/java/de/julielab/ir/evaluation/TrecPM1718LitRecallCrossval.java
+++ b/src/main/java/de/julielab/ir/evaluation/TrecPM1718LitRecallCrossval.java
@@ -36,9 +36,9 @@ public class TrecPM1718LitRecallCrossval {
 
         String experimentName = "Base";
         File topicsFile2017 = new File(CSVStatsWriter.class.getResource("/topics/topics2017.xml").getPath());
-        final TopicSet topics2017 = new TopicSet(topicsFile2017, Challenge.TREC_PM, Task.PUBMED, 2017);
+        final TopicSet topics2017 = new TopicSet(topicsFile2017, Challenge.TREC_PM, 2017);
         File topicsFile2018 = new File(CSVStatsWriter.class.getResource("/topics/topics2018.xml").getPath());
-        final TopicSet topics2018 = new TopicSet(topicsFile2018, Challenge.TREC_PM, Task.PUBMED, 2018);
+        final TopicSet topics2018 = new TopicSet(topicsFile2018, Challenge.TREC_PM, 2018);
 
         final TrecQrelGoldStandard<Topic> trecPmLit2017 = new TrecQrelGoldStandard<>(Challenge.TREC_PM, Task.PUBMED, 2017, topics2017.getTopics(), Path.of("src", "main", "resources", "gold-standard", "qrels-treceval-abstracts.2017.txt").toFile(), Path.of("src", "main", "resources", "gold-standard", "sample-qrels-final-abstracts.2017.txt").toFile());
         final TrecQrelGoldStandard<Topic> trecPmLit2018 = new TrecQrelGoldStandard<>(Challenge.TREC_PM, Task.PUBMED, 2018, topics2018.getTopics(), Path.of("src", "main", "resources", "gold-standard", "qrels-treceval-abstracts.2018.txt").toFile(), Path.of("src", "main", "resources", "gold-standard", "qrels-sample-abstracts.2018.txt").toFile());

--- a/src/main/java/de/julielab/ir/model/QueryDescription.java
+++ b/src/main/java/de/julielab/ir/model/QueryDescription.java
@@ -37,14 +37,6 @@ public abstract class QueryDescription {
         this.challenge = challenge;
     }
 
-    public Task getTask() {
-        return task;
-    }
-
-    public void setTask(Task task) {
-        this.task = task;
-    }
-
     public int getYear() {
         return year;
     }

--- a/src/test/java/at/medunigraz/imi/bst/retrieval/RetrievalTest.java
+++ b/src/test/java/at/medunigraz/imi/bst/retrieval/RetrievalTest.java
@@ -25,7 +25,7 @@ public class RetrievalTest {
     @Test
     public void withSize() {
         final Task task = Task.PUBMED;
-        final List<Topic> topics = new TopicSet(TOPICS, Challenge.TREC_PM, Task.PUBMED, 2019).getTopics();
+        final List<Topic> topics = new TopicSet(TOPICS, Challenge.TREC_PM, 2019).getTopics();
         final int SIZE = 10;
 
         ResultList<Topic> firstTopicResults = new TrecPmRetrieval()

--- a/src/test/java/at/medunigraz/imi/bst/trec/model/TopicSetTest.java
+++ b/src/test/java/at/medunigraz/imi/bst/trec/model/TopicSetTest.java
@@ -13,10 +13,10 @@ public class TopicSetTest {
 	@Test
 	public void testFromXML() {
 		File topicsFile = new File(getClass().getResource("/topics/topics2017.xml").getPath());
-		List<Topic> topics = (new TopicSet(topicsFile, Challenge.TREC_PM, Task.PUBMED, 2017)).getTopics();
+		List<Topic> topics = (new TopicSet(topicsFile, Challenge.TREC_PM, 2017)).getTopics();
 		
 		assertEquals(30, topics.size());
-		assertTrue(topics.contains(new Topic().withChallenge(Challenge.TREC_PM).withTask(Task.PUBMED).withYear(2017).withNumber(30)));
+		assertTrue(topics.contains(new Topic().withChallenge(Challenge.TREC_PM).withYear(2017).withNumber(30)));
 		
 		Topic firstTopic = topics.iterator().next();
 		assertEquals(1, firstTopic.getNumber());

--- a/src/test/java/at/medunigraz/imi/bst/trec/query/DiseaseUmlsHypernymQueryDecoratorTest.java
+++ b/src/test/java/at/medunigraz/imi/bst/trec/query/DiseaseUmlsHypernymQueryDecoratorTest.java
@@ -1,7 +1,6 @@
 package at.medunigraz.imi.bst.trec.query;
 
 import at.medunigraz.imi.bst.trec.model.Challenge;
-import at.medunigraz.imi.bst.trec.model.Task;
 import at.medunigraz.imi.bst.trec.model.Topic;
 import at.medunigraz.imi.bst.trec.model.TopicSet;
 import de.julielab.ir.umls.UmlsRelationsProvider;
@@ -9,7 +8,6 @@ import de.julielab.ir.umls.UmlsSynsetProvider;
 import org.junit.Test;
 
 import java.io.File;
-import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -30,7 +28,7 @@ public class DiseaseUmlsHypernymQueryDecoratorTest {
         final DiseaseUmlsHypernymQueryDecorator decorator = new DiseaseUmlsHypernymQueryDecorator(dummyQuery);
         decorator.setSynsetProvider(new UmlsSynsetTestProvider());
         decorator.setRelationsProvider(new UmlsRelationsTestProvider());
-        final TopicSet topicSet = new TopicSet(new File("src/main/resources/topics/topics2018.xml"), Challenge.TREC_PM, Task.PUBMED, 2017);
+        final TopicSet topicSet = new TopicSet(new File("src/main/resources/topics/topics2018.xml"), Challenge.TREC_PM, 2017);
         for (Topic topic : topicSet.getTopics()) {
             decorator.expandTopic(topic);
             if (topic.getDisease().equals("melanoma"))

--- a/src/test/java/at/medunigraz/imi/bst/trec/query/DiseaseUmlsSynonymQueryDecoratorTest.java
+++ b/src/test/java/at/medunigraz/imi/bst/trec/query/DiseaseUmlsSynonymQueryDecoratorTest.java
@@ -1,7 +1,6 @@
 package at.medunigraz.imi.bst.trec.query;
 
 import at.medunigraz.imi.bst.trec.model.Challenge;
-import at.medunigraz.imi.bst.trec.model.Task;
 import at.medunigraz.imi.bst.trec.model.Topic;
 import at.medunigraz.imi.bst.trec.model.TopicSet;
 import de.julielab.ir.umls.UmlsSynsetProvider;
@@ -21,7 +20,7 @@ public class DiseaseUmlsSynonymQueryDecoratorTest {
         DummyElasticSearchQuery dummyQuery = new DummyElasticSearchQuery();
         final DiseaseUmlsSynonymQueryDecorator decorator = new DiseaseUmlsSynonymQueryDecorator(dummyQuery);
         decorator.setUmlsSynsetProvider(new UmlsSynsetTestProvider(false));
-        final TopicSet topicSet = new TopicSet(new File("src/main/resources/topics/topics2018.xml"), Challenge.TREC_PM, Task.PUBMED, 2017);
+        final TopicSet topicSet = new TopicSet(new File("src/main/resources/topics/topics2018.xml"), Challenge.TREC_PM, 2017);
         for (Topic topic : topicSet.getTopics()) {
             decorator.expandTopic(topic);
             if (topic.getDisease().equals("melanoma"))

--- a/src/test/java/de/julielab/ir/goldstandards/TrecQrelGoldStandardTest.java
+++ b/src/test/java/de/julielab/ir/goldstandards/TrecQrelGoldStandardTest.java
@@ -22,7 +22,7 @@ public class TrecQrelGoldStandardTest {
     @Rule
     public TemporaryFolder testFolder = new TemporaryFolder();
 
-    private static final TopicSet TOPICS = new TopicSet(new File(TrecQrelGoldStandardTest.class.getResource("/topics/topics2017.xml").getPath()), Challenge.TREC_PM, Task.PUBMED, 2017);
+    private static final TopicSet TOPICS = new TopicSet(new File(TrecQrelGoldStandardTest.class.getResource("/topics/topics2017.xml").getPath()), Challenge.TREC_PM, 2017);
     private static final File QRELS = new File(TrecQrelGoldStandardTest.class.getResource("/gold-standard/qrels-treceval-abstracts.2017.txt").getPath());
     private static final File SAMPLE_QRELS = new File(TrecQrelGoldStandardTest.class.getResource("/gold-standard/sample-qrels-final-abstracts.2017.txt").getPath());
 

--- a/src/test/java/de/julielab/ir/ltr/features/TopicFieldsCasAnnotatorTest.java
+++ b/src/test/java/de/julielab/ir/ltr/features/TopicFieldsCasAnnotatorTest.java
@@ -1,10 +1,8 @@
 package de.julielab.ir.ltr.features;
 
 import at.medunigraz.imi.bst.trec.model.Challenge;
-import at.medunigraz.imi.bst.trec.model.Task;
 import at.medunigraz.imi.bst.trec.model.Topic;
 import at.medunigraz.imi.bst.trec.model.TopicSet;
-import de.julielab.ir.ltr.features.featuregroups.TopicMatchFeatureGroup;
 import de.julielab.ir.ltr.features.featurenames.MatchType;
 import de.julielab.jcore.types.Disease;
 import de.julielab.jcore.types.Gene;
@@ -18,11 +16,11 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 public class TopicFieldsCasAnnotatorTest {
     @Test
     public void test() throws Exception {
-        final TopicSet topicSet = new TopicSet(new File(getClass().getResource("/topics/topics2018.xml").getFile()), Challenge.TREC_PM, Task.PUBMED, 2018);
+        final TopicSet topicSet = new TopicSet(new File(getClass().getResource("/topics/topics2018.xml").getFile()), Challenge.TREC_PM, 2018);
         final Topic testTopic = topicSet.getTopics().get(4);
         // This topic matches to the document text
         // The following topic expansions are semantic nonsense and just serve the test.

--- a/src/test/java/de/julielab/ir/ltr/features/featuregroup/TopicMatchFeatureGroupTest.java
+++ b/src/test/java/de/julielab/ir/ltr/features/featuregroup/TopicMatchFeatureGroupTest.java
@@ -1,7 +1,6 @@
 package de.julielab.ir.ltr.features.featuregroup;
 
 import at.medunigraz.imi.bst.trec.model.Challenge;
-import at.medunigraz.imi.bst.trec.model.Task;
 import at.medunigraz.imi.bst.trec.model.Topic;
 import at.medunigraz.imi.bst.trec.model.TopicSet;
 import cc.mallet.pipe.Pipe;
@@ -36,7 +35,7 @@ public class TopicMatchFeatureGroupTest {
         FeatureControlCenter.initialize(featureConfig);
       //  featureConfig.addProperty(slash(FEATUREGROUPS, FEATUREGROUP+ NAME_ATTR), RunTopicMatchAnnotatorFeatureGroup.);
 
-        final TopicSet topicSet = new TopicSet(new File(getClass().getResource("/topics/topics2018.xml").getFile()), Challenge.TREC_PM, Task.PUBMED, 2018);
+        final TopicSet topicSet = new TopicSet(new File(getClass().getResource("/topics/topics2018.xml").getFile()), Challenge.TREC_PM, 2018);
         final Topic testTopic = topicSet.getTopics().get(4);
         // This topic matches to the document text
         // The following topic expansions are semantic nonsense and just serve the test.


### PR DESCRIPTION
The only technical reason to have a `Topic` depend on `Task` was to be able to reuse `Retrieval` and `ElasticSearchQuery` objects. However, they should not be reused for different tasks because it's hard to keep state with a decorator chain.

This removes such dependence to make code simpler. It also removes an `ElasticSearchQuery` constructor that allowed such reuse (with an unused `GoldStandard` parameter).

This fixes #23.