### PR TITLE
Make gold standards encapsulate a single, in-memory, data model

### DIFF
--- a/src/main/java/de/julielab/ir/evaluation/TrecPM1718LitCrossval.java
+++ b/src/main/java/de/julielab/ir/evaluation/TrecPM1718LitCrossval.java
@@ -54,9 +54,10 @@ public class TrecPM1718LitCrossval {
         final TopicSet topics2017 = TrecPMTopicSetFactory.topics2017();
         final TopicSet topics2018 = TrecPMTopicSetFactory.topics2018();
 
-        final TrecQrelGoldStandard<Topic> trecPmLit2017 = new TrecQrelGoldStandard<>(Challenge.TREC_PM, Task.PUBMED, 2017, topics2017.getTopics(), Path.of("src", "main", "resources", "gold-standard", "qrels-treceval-abstracts.2017.txt").toFile(), Path.of("src", "main", "resources", "gold-standard", "sample-qrels-final-abstracts.2017.txt").toFile());
-        final TrecQrelGoldStandard<Topic> trecPmLit2018 = new TrecQrelGoldStandard<>(Challenge.TREC_PM, Task.PUBMED, 2018, topics2018.getTopics(), Path.of("src", "main", "resources", "gold-standard", "qrels-treceval-abstracts.2018.txt").toFile(), Path.of("src", "main", "resources", "gold-standard", "qrels-sample-abstracts.2018.txt").toFile());
-        final AggregatedTrecQrelGoldStandard<Topic> aggregatedGoldStandard = new AggregatedTrecQrelGoldStandard<>(Path.of("aggregatedQrels", "trecPmLit2017-2018.qrel").toFile(), Path.of("aggregatedQrels", "sampleTrecPmLit2017-2018.qrel").toFile(), trecPmLit2017, trecPmLit2018);
+        final TrecQrelGoldStandard<Topic> trecPmLit2017 = new TrecQrelGoldStandard<>(Challenge.TREC_PM, Task.PUBMED, 2017, topics2017.getTopics(), Path.of("src", "main", "resources", "gold-standard", "sample-qrels-final-abstracts.2017.txt").toFile());
+        final TrecQrelGoldStandard<Topic> trecPmLit2018 = new TrecQrelGoldStandard<>(Challenge.TREC_PM, Task.PUBMED, 2018, topics2018.getTopics(), Path.of("src", "main", "resources", "gold-standard", "qrels-sample-abstracts.2018.txt").toFile());
+//        final AggregatedTrecQrelGoldStandard<Topic> aggregatedGoldStandard = new AggregatedTrecQrelGoldStandard<>(, , trecPmLit2017, trecPmLit2018);
+        final AggregatedTrecQrelGoldStandard<Topic> aggregatedGoldStandard = new AggregatedTrecQrelGoldStandard<>(trecPmLit2017, trecPmLit2018);
 
         final List<List<Topic>> topicPartitioning = aggregatedGoldStandard.createStratifiedTopicPartitioning(CROSSVAL_SIZE, Topic::getDisease);
 
@@ -134,8 +135,12 @@ public class TrecPM1718LitCrossval {
                 tw.writeDocuments(lastDocumentLists, IRScore.LTR, aggregatedGoldStandard.getQueryIdFunction());
             }
 
+            final File qRelFile = Path.of("aggregatedQrels", "trecPmLit2017-2018.qrel").toFile();
+            aggregatedGoldStandard.writeQrelFile(qRelFile);
+            final File sampleQrelFile = Path.of("aggregatedQrels", "sampleTrecPmLit2017-2018.qrel").toFile();
+            aggregatedGoldStandard.writeSampleQrelFile(sampleQrelFile);
 
-            final TrecMetricsCreator trecMetricsCreator = new TrecMetricsCreator("pmround" + i + "ltr", "pmround" + i + "ltr", output, aggregatedGoldStandard.getQrelFile(), 1000, false, "stats-tr/", GoldStandard.OFFICIAL, aggregatedGoldStandard.getSampleQrelFile());
+            final TrecMetricsCreator trecMetricsCreator = new TrecMetricsCreator("pmround" + i + "ltr", "pmround" + i + "ltr", output, qRelFile, 1000, false, "stats-tr/", GoldStandard.OFFICIAL, sampleQrelFile);
             final Metrics metrics = trecMetricsCreator.computeMetrics();
             allLtrMetrics.add(metrics);
 

--- a/src/main/java/de/julielab/ir/evaluation/TrecPM1718LitRecallCrossval.java
+++ b/src/main/java/de/julielab/ir/evaluation/TrecPM1718LitRecallCrossval.java
@@ -37,9 +37,9 @@ public class TrecPM1718LitRecallCrossval {
         final TopicSet topics2017 = TrecPMTopicSetFactory.topics2017();
         final TopicSet topics2018 = TrecPMTopicSetFactory.topics2018();
 
-        final TrecQrelGoldStandard<Topic> trecPmLit2017 = new TrecQrelGoldStandard<>(Challenge.TREC_PM, Task.PUBMED, 2017, topics2017.getTopics(), Path.of("src", "main", "resources", "gold-standard", "qrels-treceval-abstracts.2017.txt").toFile(), Path.of("src", "main", "resources", "gold-standard", "sample-qrels-final-abstracts.2017.txt").toFile());
-        final TrecQrelGoldStandard<Topic> trecPmLit2018 = new TrecQrelGoldStandard<>(Challenge.TREC_PM, Task.PUBMED, 2018, topics2018.getTopics(), Path.of("src", "main", "resources", "gold-standard", "qrels-treceval-abstracts.2018.txt").toFile(), Path.of("src", "main", "resources", "gold-standard", "qrels-sample-abstracts.2018.txt").toFile());
-        final AggregatedTrecQrelGoldStandard<Topic> aggregatedGoldStandard = new AggregatedTrecQrelGoldStandard<>(Path.of("aggregatedQrels", "trecPmLit2017-2018.qrel").toFile(), Path.of("aggregatedQrels", "sampleTrecPmLit2017-2018.qrel").toFile(), trecPmLit2017, trecPmLit2018);
+        final TrecQrelGoldStandard<Topic> trecPmLit2017 = new TrecQrelGoldStandard<>(Challenge.TREC_PM, Task.PUBMED, 2017, topics2017.getTopics(), Path.of("src", "main", "resources", "gold-standard", "sample-qrels-final-abstracts.2017.txt").toFile());
+        final TrecQrelGoldStandard<Topic> trecPmLit2018 = new TrecQrelGoldStandard<>(Challenge.TREC_PM, Task.PUBMED, 2018, topics2018.getTopics(), Path.of("src", "main", "resources", "gold-standard", "qrels-sample-abstracts.2018.txt").toFile());
+        final AggregatedTrecQrelGoldStandard<Topic> aggregatedGoldStandard = new AggregatedTrecQrelGoldStandard<>(trecPmLit2017, trecPmLit2018);
 
         final List<List<Topic>> topicPartitioning = aggregatedGoldStandard.createStratifiedTopicPartitioning(CROSSVAL_SIZE, Topic::getDisease);
 

--- a/src/main/java/de/julielab/ir/goldstandards/AggregatedGoldStandard.java
+++ b/src/main/java/de/julielab/ir/goldstandards/AggregatedGoldStandard.java
@@ -29,28 +29,12 @@ public abstract class AggregatedGoldStandard<Q extends QueryDescription> impleme
     protected Map<String, AtomicGoldStandard<Q>> goldStandards;
     private List<Q> queryList;
     private Map<Q, DocumentList> documentsByQuery;
-    private File qrelFile;
-    private File sampleQrelFile;
 
-    public AggregatedGoldStandard(Logger log, File qrelFile, Function<Document, String> qrelRecordFunction, AtomicGoldStandard... goldStandards) {
-        this(log, qrelFile, null, qrelRecordFunction, null, goldStandards);
-    }
-
-    public AggregatedGoldStandard(Logger log, File qrelFile, File sampleQrelFile, Function<Document, String> qrelRecordFunction, Function<Document, String> sampleQrelRecordFunction, AtomicGoldStandard... goldStandards) {
+    public AggregatedGoldStandard(Logger log, AtomicGoldStandard... goldStandards) {
         this.log = log;
-        this.qrelFile = qrelFile;
-        this.sampleQrelFile = sampleQrelFile;
         this.goldStandards = Stream.of(goldStandards).collect(Collectors.toMap(AtomicGoldStandard::getDatasetId, Function.identity()));
-        if (qrelFile != null)
-            writeAggregatedQrelFile(qrelFile, goldStandards, gs -> gs.getQrelDocuments(), qrelRecordFunction);
-        if (sampleQrelFile != null) {
-            writeAggregatedQrelFile(sampleQrelFile, goldStandards, gs -> gs.getSampleQrelDocuments(), sampleQrelRecordFunction);
-        }
-    }
-
-    @Override
-    public DocumentList<Q> getSampleQrelDocuments() {
-        return goldStandards.values().stream().map(GoldStandard::getSampleQrelDocuments).flatMap(Collection::stream).collect(Collectors.toCollection(DocumentList::new));
+//        if (qrelFile != null)
+//            writeAggregatedQrelFile(qrelFile, goldStandards, gs -> gs.getQrelDocuments(), qrelRecordFunction);
     }
 
     @Override
@@ -136,15 +120,5 @@ public abstract class AggregatedGoldStandard<Q extends QueryDescription> impleme
                 log.error("Exception while writing aggregated qrel file to {}", qrelFile, e);
             }
         }
-    }
-
-    @Override
-    public File getQrelFile() {
-        return qrelFile;
-    }
-
-    @Override
-    public File getSampleQrelFile() {
-        return sampleQrelFile;
     }
 }

--- a/src/main/java/de/julielab/ir/goldstandards/AtomicGoldStandard.java
+++ b/src/main/java/de/julielab/ir/goldstandards/AtomicGoldStandard.java
@@ -25,22 +25,12 @@ public abstract class AtomicGoldStandard<Q extends QueryDescription> implements 
      */
     protected DocumentList<Q> qrelDocuments;
     /**
-     * All documents from the sample qrel file, across all queries
-     */
-    protected DocumentList<Q> sampleQrelDocuments;
-    /**
      * All queries.
      */
     protected List<Q> queries;
     protected Challenge challenge;
     protected Task task;
     protected int year;
-
-    /**
-     * @deprecated qrelDocuments might have changed since initialization. Use `writeQrelFile` instead.
-     */
-    protected File qrels;
-    protected File sampleQrels;
 
     /**
      * The documents in {@link #qrelDocuments} grouped by query.
@@ -51,15 +41,12 @@ public abstract class AtomicGoldStandard<Q extends QueryDescription> implements 
      */
     protected Map<Integer, Q> queriesByNumber;
 
-    public AtomicGoldStandard(Challenge challenge, Task task, int year, List<Q> queries, File qrelsFile, File sampleQrelsFile, BiFunction<File, Map<Integer, Q>, DocumentList<Q>> qrelsReader, BiFunction<File, Map<Integer, Q>, DocumentList<Q>> sampleQrelsReader) {
+    public AtomicGoldStandard(Challenge challenge, Task task, int year, List<Q> queries, File qrelsFile, BiFunction<File, Map<Integer, Q>, DocumentList<Q>> qrelsReader) {
         this.challenge = challenge;
         this.task = task;
         this.year = year;
         this.queries = queries;
-        this.qrels = qrelsFile;
-        this.sampleQrels = sampleQrelsFile;
         qrelDocuments = qrelsReader.apply(qrelsFile, getQueriesByNumber());
-        sampleQrelDocuments = sampleQrelsReader.apply(sampleQrelsFile, getQueriesByNumber());
     }
 
     public AtomicGoldStandard(Challenge challenge, Task task, int year, List<Q> queries, DocumentList<Q> qrelDocuments) {
@@ -92,21 +79,6 @@ public abstract class AtomicGoldStandard<Q extends QueryDescription> implements 
         if (documentsByQuery == null)
             documentsByQuery = getQrelDocuments().stream().collect(Collectors.groupingBy(Document::getQueryDescription, Collectors.toCollection(DocumentList::new)));
         return documentsByQuery;
-    }
-
-    @Override
-    public File getQrelFile() {
-        return null;
-    }
-
-    @Override
-    public File getSampleQrelFile() {
-        return getSampleQrelFile();
-    }
-
-    @Override
-    public DocumentList<Q> getSampleQrelDocuments() {
-        return sampleQrelDocuments;
     }
 
     @Override

--- a/src/main/java/de/julielab/ir/goldstandards/GoldStandard.java
+++ b/src/main/java/de/julielab/ir/goldstandards/GoldStandard.java
@@ -47,16 +47,18 @@ public interface GoldStandard<Q extends QueryDescription> {
     Map<Q, DocumentList> getQrelDocumentsPerQuery();
 
     /**
-     * @deprecated Use `writeQrelFile` instead.
-     * @return
+     * Writes the underlying data structure to a traditional qrel file.
+     * @param qrelFile
      */
-    File getQrelFile();
-
-    File getSampleQrelFile();
-
     void writeQrelFile(File qrelFile);
 
-    DocumentList<Q> getSampleQrelDocuments();
+    /**
+     *  Writes the underlying data structure to a sample qrel file, if possible.
+     * @param qrelFile
+     */
+    void writeSampleQrelFile(File qrelFile);
+
+    boolean isSampleGoldStandard();
 
     DocumentList<Q> getQrelDocuments();
 

--- a/src/main/java/de/julielab/ir/goldstandards/GoogleSheetsGoldStandard.java
+++ b/src/main/java/de/julielab/ir/goldstandards/GoogleSheetsGoldStandard.java
@@ -103,6 +103,16 @@ public class GoogleSheetsGoldStandard<Q extends QueryDescription> extends Atomic
     }
 
     @Override
+    public void writeSampleQrelFile(File qrelFile) {
+        throw new NotImplementedException("Use TrecQrelGoldStandard.writeSampleQrelFile instead.");
+    }
+
+    @Override
+    public boolean isSampleGoldStandard() {
+        return false;
+    }
+
+    @Override
     public Function<QueryDescription, String> getQueryIdFunction() {
         return q -> String.valueOf(q.getNumber());
     }

--- a/src/test/java/de/julielab/ir/goldstandards/TrecQrelGoldStandardTest.java
+++ b/src/test/java/de/julielab/ir/goldstandards/TrecQrelGoldStandardTest.java
@@ -21,12 +21,11 @@ public class TrecQrelGoldStandardTest {
 
     private static final TopicSet TOPICS = TrecPMTopicSetFactory.topics2017();
     private static final File QRELS = new File(TrecQrelGoldStandardTest.class.getResource("/gold-standard/qrels-treceval-abstracts.2017.txt").getPath());
-    private static final File SAMPLE_QRELS = new File(TrecQrelGoldStandardTest.class.getResource("/gold-standard/sample-qrels-final-abstracts.2017.txt").getPath());
 
     @Test
     public void readQrels() {
         // TODO Use GoldStandardBuilder (#17)
-        final TrecQrelGoldStandard<Topic> gs = new TrecQrelGoldStandard<>(Challenge.TREC_PM, Task.PUBMED, 2017, TOPICS.getTopics(), QRELS, SAMPLE_QRELS);
+        final TrecQrelGoldStandard<Topic> gs = new TrecQrelGoldStandard<>(Challenge.TREC_PM, Task.PUBMED, 2017, TOPICS.getTopics(), QRELS);
 
         assertEquals(22642, gs.getQrelDocuments().size());
         assertEquals(439, gs.getQrelDocumentsForQuery(1).size());
@@ -40,7 +39,7 @@ public class TrecQrelGoldStandardTest {
         document.setId("19860577");
         document.setRelevance(2);
 
-        // Add the document to the document list
+        // Add the document to a document list
         DocumentList<Topic> qrelDocuments = new DocumentList<>();
         qrelDocuments.add(document);
 
@@ -57,7 +56,7 @@ public class TrecQrelGoldStandardTest {
     @Test
     public void readAndWriteQrels() throws IOException {
         // Read from official qrels file
-        final TrecQrelGoldStandard<Topic> officialGs = new TrecQrelGoldStandard<>(Challenge.TREC_PM, Task.PUBMED, 2017, TOPICS.getTopics(), QRELS, SAMPLE_QRELS);
+        final TrecQrelGoldStandard<Topic> officialGs = new TrecQrelGoldStandard<>(Challenge.TREC_PM, Task.PUBMED, 2017, TOPICS.getTopics(), QRELS);
 
         // Extract documents
         DocumentList<Topic> qrelDocuments = officialGs.getQrelDocuments();


### PR DESCRIPTION
Sample qrels are a superset of qrels, so there's no need to keep both around. Moreover, the `DocumentList` in a GS can be changed in memory, at which point it turns out-of-sync with the underlying file.

Change constructors so that they receive a single file and load the data from it once. When needed, a file can be created using `writeSampleQrelFile`, when data will be synced.

When a traditional qrel file is needed (e.g. statistics or 2017 CT), use `writeQrelFile` instead. Add a helper method `isSampleGoldStandard` to aid on that.

This fixes #24.