### PR TITLE
Return a traditional document list in `getQrelDocuments`

### DIFF
--- a/src/main/java/de/julielab/ir/goldstandards/AggregatedGoldStandard.java
+++ b/src/main/java/de/julielab/ir/goldstandards/AggregatedGoldStandard.java
@@ -33,8 +33,11 @@ public abstract class AggregatedGoldStandard<Q extends QueryDescription> impleme
     public AggregatedGoldStandard(Logger log, AtomicGoldStandard... goldStandards) {
         this.log = log;
         this.goldStandards = Stream.of(goldStandards).collect(Collectors.toMap(AtomicGoldStandard::getDatasetId, Function.identity()));
-//        if (qrelFile != null)
-//            writeAggregatedQrelFile(qrelFile, goldStandards, gs -> gs.getQrelDocuments(), qrelRecordFunction);
+    }
+
+    @Override
+    public DocumentList<Q> getSampleQrelDocuments() {
+        return goldStandards.values().stream().map(GoldStandard::getSampleQrelDocuments).flatMap(Collection::stream).collect(Collectors.toCollection(DocumentList::new));
     }
 
     @Override

--- a/src/main/java/de/julielab/ir/goldstandards/AtomicGoldStandard.java
+++ b/src/main/java/de/julielab/ir/goldstandards/AtomicGoldStandard.java
@@ -88,6 +88,29 @@ public abstract class AtomicGoldStandard<Q extends QueryDescription> implements 
 
     @Override
     public DocumentList<Q> getQrelDocuments() {
+        if (isSampleGoldStandard()) {
+            return convertSampleToTraditional(qrelDocuments);
+        }
+        return qrelDocuments;
+    }
+
+    /**
+     * Converts a given DocumentList to a non-stratified list.
+     * @param sampleQrelDocuments
+     * @return
+     */
+    private DocumentList<Q> convertSampleToTraditional(DocumentList<Q> sampleQrelDocuments) {
+        DocumentList<Q> ret = new DocumentList<>();
+        for (Document<Q> doc : sampleQrelDocuments) {
+            if (doc.getRelevance() != -1) {
+                ret.add(doc);
+            }
+        }
+        return ret;
+    }
+
+    @Override
+    public DocumentList<Q> getSampleQrelDocuments() {
         return qrelDocuments;
     }
 
@@ -109,7 +132,6 @@ public abstract class AtomicGoldStandard<Q extends QueryDescription> implements 
 
     @Override
     public String getDatasetId() {
-//        return Stream.of(challenge, task, year).filter(Objects::nonNull).map(String::valueOf).collect(Collectors.joining("-"));
         return String.valueOf(year);
     }
 

--- a/src/main/java/de/julielab/ir/goldstandards/GoldStandard.java
+++ b/src/main/java/de/julielab/ir/goldstandards/GoldStandard.java
@@ -62,6 +62,8 @@ public interface GoldStandard<Q extends QueryDescription> {
 
     DocumentList<Q> getQrelDocuments();
 
+    DocumentList<Q> getSampleQrelDocuments();
+
     Map<Integer, Q> getQueriesByNumber();
 
     DocumentList<Q> getQrelDocumentsForQuery(int queryId);

--- a/src/main/java/de/julielab/ir/goldstandards/TrecQrelGoldStandard.java
+++ b/src/main/java/de/julielab/ir/goldstandards/TrecQrelGoldStandard.java
@@ -99,8 +99,7 @@ public class TrecQrelGoldStandard<Q extends QueryDescription> extends AtomicGold
         if (qrelDocuments.size() == 0) {
             return false;
         }
-        // XXX Here we just use the default Java int value. However, maybe one gold standard could have a valid stratum named 0.
-        boolean isSample = qrelDocuments.get(0).getStratum() != 0;
+        boolean isSample = qrelDocuments.get(0).isStratified();
         if (!isSample) {
             log.info("This is not a sample gold standard. `sample_eval` cannot be called and thus some metrics (like infNDCG) may not be available.");
         }

--- a/src/main/java/de/julielab/ir/ltr/Document.java
+++ b/src/main/java/de/julielab/ir/ltr/Document.java
@@ -184,4 +184,9 @@ public class Document<Q extends QueryDescription> {
         }
         return normalizedDocumentText;
     }
+
+    public boolean isStratified() {
+        // XXX Here we just use the default Java int value. However, maybe one gold standard could have a valid stratum named 0.
+        return getStratum() != 0;
+    }
 }


### PR DESCRIPTION
623cce introduced a potential bug by always returning the full document list. However, some code (e.g. RankLib) might expect only positive relevance assessments.

This commit reverts to the old behavior by subsetting the list on-the-fly when required.

This fixes #60.