### PR TITLE
Switch `Retrieval` to be based on an index

### DIFF
--- a/src/main/java/at/medunigraz/imi/bst/trec/experiment/TrecPmRetrieval.java
+++ b/src/main/java/at/medunigraz/imi/bst/trec/experiment/TrecPmRetrieval.java
@@ -7,6 +7,9 @@ import at.medunigraz.imi.bst.trec.query.*;
 
 public class TrecPmRetrieval extends Retrieval<TrecPmRetrieval, Topic> {
 
+    public TrecPmRetrieval(String indexName) {
+        super(indexName);
+    }
 
     public TrecPmRetrieval withWordRemoval() {
         query = new WordRemovalQueryDecorator(query);

--- a/src/main/java/at/medunigraz/imi/bst/trec/experiment/registry/ClinicalTrialsRetrievalRegistry.java
+++ b/src/main/java/at/medunigraz/imi/bst/trec/experiment/registry/ClinicalTrialsRetrievalRegistry.java
@@ -1,7 +1,7 @@
 package at.medunigraz.imi.bst.trec.experiment.registry;
 
+import at.medunigraz.imi.bst.config.TrecConfig;
 import at.medunigraz.imi.bst.trec.experiment.TrecPmRetrieval;
-import at.medunigraz.imi.bst.trec.model.Task;
 
 import java.io.File;
 
@@ -13,31 +13,31 @@ public final class ClinicalTrialsRetrievalRegistry {
             ClinicalTrialsRetrievalRegistry.class.getResource("/templates/clinical_trials/hpictphrase.json").getFile());
 
     public static TrecPmRetrieval hpictall(int size) {
-        return new TrecPmRetrieval().withExperimentName("hpictall").withSize(size).withTarget(Task.CLINICAL_TRIALS)
+        return new TrecPmRetrieval(TrecConfig.ELASTIC_CT_INDEX).withExperimentName("hpictall").withSize(size)
                 .withSubTemplate(IMPROVED_TEMPLATE).withWordRemoval().withSolidTumor().withDiseasePreferredTerm()
                 .withDiseaseSynonym().withGeneSynonym().withGeneDescription().withGeneFamily();
     }
 
     public static TrecPmRetrieval hpictphrase(int size) {
-        return new TrecPmRetrieval().withExperimentName("hpictphrase").withSize(size).withTarget(Task.CLINICAL_TRIALS)
+        return new TrecPmRetrieval(TrecConfig.ELASTIC_CT_INDEX).withExperimentName("hpictphrase").withSize(size)
                 .withSubTemplate(PHRASE_TEMPLATE).withWordRemoval().withSolidTumor().withDiseasePreferredTerm()
                 .withDiseaseSynonym().withGeneSynonym().withGeneFamily();
     }
 
     public static TrecPmRetrieval hpictboost(int size) {
-        return new TrecPmRetrieval().withExperimentName("hpictboost").withSize(size).withTarget(Task.CLINICAL_TRIALS)
+        return new TrecPmRetrieval(TrecConfig.ELASTIC_CT_INDEX).withExperimentName("hpictboost").withSize(size)
                 .withSubTemplate(IMPROVED_TEMPLATE).withWordRemoval().withSolidTumor().withDiseasePreferredTerm()
                 .withDiseaseSynonym().withGeneSynonym().withGeneFamily();
     }
 
     public static TrecPmRetrieval hpictcommon(int size) {
-        return new TrecPmRetrieval().withExperimentName("hpictcommon").withSize(size).withTarget(Task.CLINICAL_TRIALS)
+        return new TrecPmRetrieval(TrecConfig.ELASTIC_CT_INDEX).withExperimentName("hpictcommon").withSize(size)
                 .withSubTemplate(IMPROVED_TEMPLATE).withWordRemoval().withDiseasePreferredTerm().withDiseaseSynonym()
                 .withGeneSynonym();
     }
 
     public static TrecPmRetrieval hpictbase(int size) {
-        return new TrecPmRetrieval().withExperimentName("hpictbase").withSize(size).withTarget(Task.CLINICAL_TRIALS)
+        return new TrecPmRetrieval(TrecConfig.ELASTIC_CT_INDEX).withExperimentName("hpictbase").withSize(size)
                 .withSubTemplate(IMPROVED_TEMPLATE);
     }
 }

--- a/src/main/java/at/medunigraz/imi/bst/trec/experiment/registry/LiteratureArticlesRetrievalRegistry.java
+++ b/src/main/java/at/medunigraz/imi/bst/trec/experiment/registry/LiteratureArticlesRetrievalRegistry.java
@@ -1,7 +1,7 @@
 package at.medunigraz.imi.bst.trec.experiment.registry;
 
+import at.medunigraz.imi.bst.config.TrecConfig;
 import at.medunigraz.imi.bst.trec.experiment.TrecPmRetrieval;
-import at.medunigraz.imi.bst.trec.model.Task;
 
 import java.io.File;
 
@@ -19,41 +19,41 @@ public final class LiteratureArticlesRetrievalRegistry {
             LiteratureArticlesRetrievalRegistry.class.getResource("/templates/biomedical_articles/boost.json").getFile());
 
     public static TrecPmRetrieval hpipubclass(int size) {
-        return new TrecPmRetrieval().withExperimentName("hpipubclass").withSize(size).withTarget(Task.PUBMED)
+        return new TrecPmRetrieval(TrecConfig.ELASTIC_BA_INDEX).withExperimentName("hpipubclass").withSize(size)
                 .withSubTemplate(EXTRA_BOOST_TEMPLATE).withWordRemoval().withGeneSynonym()
                 .withDiseasePreferredTerm().withGeneDescription().withDiseaseSynonym();
     }
 
     public static TrecPmRetrieval hpipubnone(int size) {
-        return new TrecPmRetrieval().withExperimentName("hpipubnone").withSize(size).withTarget(Task.PUBMED)
+        return new TrecPmRetrieval(TrecConfig.ELASTIC_BA_INDEX).withExperimentName("hpipubnone").withSize(size)
                 .withSubTemplate(NONE_TEMPLATE).withWordRemoval().withGeneSynonym()
                 .withDiseasePreferredTerm().withGeneDescription().withDiseaseSynonym();
     }
 
     public static TrecPmRetrieval hpipubboost(int size) {
-        return new TrecPmRetrieval().withExperimentName("hpipubboost").withSize(size).withTarget(Task.PUBMED)
+        return new TrecPmRetrieval(TrecConfig.ELASTIC_BA_INDEX).withExperimentName("hpipubboost").withSize(size)
                 .withSubTemplate(IMPROVED_TEMPLATE).withWordRemoval().withGeneSynonym()
                 .withDiseasePreferredTerm().withGeneDescription().withDiseaseSynonym();
     }
 
     public static TrecPmRetrieval hpipubcommon(int size) {
-        return new TrecPmRetrieval().withExperimentName("hpipubcommon").withSize(size).withTarget(Task.PUBMED)
+        return new TrecPmRetrieval(TrecConfig.ELASTIC_BA_INDEX).withExperimentName("hpipubcommon").withSize(size)
                 .withSubTemplate(NONE_TEMPLATE).withWordRemoval().withGeneSynonym()
                 .withDiseasePreferredTerm().withDiseaseSynonym();
     }
 
     public static TrecPmRetrieval hpipubbase(int size) {
-        return new TrecPmRetrieval().withExperimentName("hpipubbase").withSize(size).withTarget(Task.PUBMED)
+        return new TrecPmRetrieval(TrecConfig.ELASTIC_BA_INDEX).withExperimentName("hpipubbase").withSize(size)
                 .withSubTemplate(NONE_TEMPLATE);
     }
 
     public static TrecPmRetrieval keyword(int size, String keyword) {
-        return new TrecPmRetrieval().withExperimentName(keyword).withSize(size).withTarget(Task.PUBMED)
+        return new TrecPmRetrieval(TrecConfig.ELASTIC_BA_INDEX).withExperimentName(keyword).withSize(size)
                 .withProperties("keyword", keyword).withTemplate(KEYWORD_TEMPLATE).withWordRemoval();
     }
 
     public static TrecPmRetrieval boost(int size, String boost) {
-        return new TrecPmRetrieval().withSize(size).withTarget(Task.PUBMED)
+        return new TrecPmRetrieval(TrecConfig.ELASTIC_BA_INDEX).withSize(size)
                 .withProperties("keyword", boost).withTemplate(BOOST_TEMPLATE).withWordRemoval();
     }
 

--- a/src/main/java/de/julielab/ir/evaluation/TrecPM1718LitCrossval.java
+++ b/src/main/java/de/julielab/ir/evaluation/TrecPM1718LitCrossval.java
@@ -63,7 +63,7 @@ public class TrecPM1718LitCrossval {
 
         final File noClassifierTemplate = new File(
                 TrecPM1718LitCrossval.class.getResource("/templates/biomedical_articles/hpipubnone.json").getFile());
-        final TrecPmRetrieval retrieval = new TrecPmRetrieval().withTarget(Task.PUBMED).withResultsDir("myresultsdir/").withSubTemplate(noClassifierTemplate).withGeneSynonym().withDiseaseSynonym();
+        final TrecPmRetrieval retrieval = new TrecPmRetrieval(TrecConfig.ELASTIC_BA_INDEX).withResultsDir("myresultsdir/").withSubTemplate(noClassifierTemplate).withGeneSynonym().withDiseaseSynonym();
 
         List<Double> rankLibScores = new ArrayList<>();
         List<Metrics> allESMetrics = new ArrayList<>();

--- a/src/main/java/de/julielab/ir/evaluation/TrecPM1718LitRecallCrossval.java
+++ b/src/main/java/de/julielab/ir/evaluation/TrecPM1718LitRecallCrossval.java
@@ -1,5 +1,6 @@
 package de.julielab.ir.evaluation;
 
+import at.medunigraz.imi.bst.config.TrecConfig;
 import at.medunigraz.imi.bst.trec.experiment.Experiment;
 import at.medunigraz.imi.bst.trec.experiment.TrecPmRetrieval;
 import at.medunigraz.imi.bst.trec.model.*;
@@ -31,7 +32,7 @@ public class TrecPM1718LitRecallCrossval {
 
         final File noClassifierTemplate = new File(
                 TrecPM1718LitRecallCrossval.class.getResource("/templates/biomedical_articles/hpipubnone.json").getFile());
-        final TrecPmRetrieval retrieval = new TrecPmRetrieval().withTarget(Task.PUBMED).withResultsDir("myresultsdir/").withSubTemplate(noClassifierTemplate).withGeneSynonym().withDiseaseSynonym().withResistantDrugs();
+        final TrecPmRetrieval retrieval = new TrecPmRetrieval(TrecConfig.ELASTIC_BA_INDEX).withResultsDir("myresultsdir/").withSubTemplate(noClassifierTemplate).withGeneSynonym().withDiseaseSynonym().withResistantDrugs();
 
         String experimentName = "Base";
 

--- a/src/test/java/at/medunigraz/imi/bst/retrieval/RetrievalTest.java
+++ b/src/test/java/at/medunigraz/imi/bst/retrieval/RetrievalTest.java
@@ -1,8 +1,8 @@
 package at.medunigraz.imi.bst.retrieval;
 
+import at.medunigraz.imi.bst.config.TrecConfig;
 import at.medunigraz.imi.bst.trec.experiment.TrecPmRetrieval;
 import at.medunigraz.imi.bst.trec.model.ResultList;
-import at.medunigraz.imi.bst.trec.model.Task;
 import at.medunigraz.imi.bst.trec.model.Topic;
 import at.medunigraz.imi.bst.trec.model.TrecPMTopicSetFactory;
 import at.medunigraz.imi.bst.trec.utils.ConnectionUtils;
@@ -27,13 +27,12 @@ public class RetrievalTest {
 
     @Test
     public void withSize() {
-        final Task task = Task.PUBMED;
+        final String indexName = TrecConfig.ELASTIC_BA_INDEX;
         final List<Topic> topics = TrecPMTopicSetFactory.topics2019().getTopics();
         final int SIZE = 10;
 
-        ResultList<Topic> firstTopicResults = new TrecPmRetrieval()
+        ResultList<Topic> firstTopicResults = new TrecPmRetrieval(indexName)
                 .withSize(SIZE)
-                .withTarget(task)
                 .withTemplate(TEMPLATE)
                 .retrieve(topics, q -> String.valueOf(q.getNumber()))
                 .get(0);


### PR DESCRIPTION
Instead of deciding the index upon a task, receive the index name directly. This allows different kinds of indices, e.g. with different similarity measures.

Initialize the index at a new mandatory constructor. This avoids the problem of calling decorators in the wrong order.

This fixes #56.