### PR TITLE
Preserve evaluator output in a file

### DIFF
--- a/src/main/java/at/medunigraz/imi/bst/trec/evaluator/SampleEval.java
+++ b/src/main/java/at/medunigraz/imi/bst/trec/evaluator/SampleEval.java
@@ -2,6 +2,7 @@ package at.medunigraz.imi.bst.trec.evaluator;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class SampleEval extends AbstractEvaluator {
@@ -12,11 +13,10 @@ public class SampleEval extends AbstractEvaluator {
      * $ perl sample_eval.pl
      * Usage:  sample_eval.pl [-q] <qrel_file> <trec_file>
      */
-    private static final String COMMAND = "perl " + SCRIPT + " -q";
+    private static final List<String> COMMAND = Arrays.asList("perl", SCRIPT, "-q");
 
-    public SampleEval(File goldStandard, File results) {
-        super.goldStandard = goldStandard;
-        super.results = results;
+    public SampleEval(File goldStandard, File results, File output) {
+        super(goldStandard, results, output);
         evaluate();
     }
 
@@ -25,8 +25,7 @@ public class SampleEval extends AbstractEvaluator {
     }
 
     public List<String> getFullCommand() {
-        List<String> fullCommand = new ArrayList<>();
-        fullCommand.add(COMMAND);
+        List<String> fullCommand = new ArrayList<>(COMMAND);
         fullCommand.add(goldStandard.getAbsolutePath());
         fullCommand.add(results.getAbsolutePath());
         return fullCommand;

--- a/src/main/java/at/medunigraz/imi/bst/trec/evaluator/TrecEval.java
+++ b/src/main/java/at/medunigraz/imi/bst/trec/evaluator/TrecEval.java
@@ -4,6 +4,7 @@ import at.medunigraz.imi.bst.config.TrecConfig;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class TrecEval extends AbstractEvaluator {
@@ -13,24 +14,24 @@ public class TrecEval extends AbstractEvaluator {
     /**
      * -m all_trec -q -c -M1000
      */
-    private String command;
+    private List<String> command;
 
-    public TrecEval(File goldStandard, File results) {
-        this(goldStandard, results, TrecConfig.SIZE, true);
+    public TrecEval(File goldStandard, File results, File output) {
+        this(goldStandard, results, output, TrecConfig.SIZE, true);
     }
 
-    public TrecEval(File goldStandard, File results, int k, boolean calculateWithMissingResults) {
-        super.goldStandard = goldStandard;
-        super.results = results;
-        command = TREC_EVAL_SCRIPT + " -m all_trec -q -M"+k;
-        if (calculateWithMissingResults)
-            command = command + " -c";
+    public TrecEval(File goldStandard, File results, File output, int k, boolean calculateWithMissingResults) {
+        super(goldStandard, results, output);
+        command = Arrays.asList(TREC_EVAL_SCRIPT, "-m", "all_trec", "-q", "-M", String.valueOf(k));
+        if (calculateWithMissingResults) {
+            command = new ArrayList<>(command);
+            command.add("-c");
+        }
         evaluate();
     }
 
     public List<String> getFullCommand() {
-        List<String> fullCommand = new ArrayList<>();
-        fullCommand.add(command);
+        List<String> fullCommand = new ArrayList<>(command);
         fullCommand.add(goldStandard.getAbsolutePath());
         fullCommand.add(results.getAbsolutePath());
         return fullCommand;

--- a/src/test/java/at/medunigraz/imi/bst/trec/evaluator/SampleEvalTest.java
+++ b/src/test/java/at/medunigraz/imi/bst/trec/evaluator/SampleEvalTest.java
@@ -12,6 +12,7 @@ public class SampleEvalTest {
 
     private static final String GOLD = "/gold-standard/test-sample.qrels";
     private static final String RESULTS = "/results/test.trec_results";
+    private static final String OUTPUT = "/stats/test.sampleval";
 
     @Before
     public void setUp() {
@@ -22,8 +23,9 @@ public class SampleEvalTest {
     public void evaluate() {
         File goldStandard = new File(getClass().getResource(GOLD).getFile());
         File results = new File(getClass().getResource(RESULTS).getFile());
+        File output = new File(getClass().getResource(OUTPUT).getFile());
 
-        SampleEval t = new SampleEval(goldStandard, results);
+        SampleEval t = new SampleEval(goldStandard, results, output);
         assertEquals(0.6309, t.getInfNDCG(), 0.00001);
         assertEquals(0.5, t.getInfAP(), 0.00001);
     }

--- a/src/test/java/at/medunigraz/imi/bst/trec/evaluator/TrecEvalTest.java
+++ b/src/test/java/at/medunigraz/imi/bst/trec/evaluator/TrecEvalTest.java
@@ -12,6 +12,7 @@ public class TrecEvalTest {
 
     private static final String GOLD = "/gold-standard/test.qrels";
     private static final String RESULTS = "/results/test.trec_results";
+    private static final String OUTPUT = "/stats/test.trec_eval";
 
     @Before
     public void setUp() {
@@ -22,8 +23,9 @@ public class TrecEvalTest {
     public void testEvaluate() {
         File goldStandard = new File(getClass().getResource(GOLD).getFile());
         File results = new File(getClass().getResource(RESULTS).getFile());
+        File output = new File(getClass().getResource(OUTPUT).getFile());
 
-        TrecEval t = new TrecEval(goldStandard, results);
+        TrecEval t = new TrecEval(goldStandard, results, output);
         assertEquals(0.6309, t.getNDCG(), 0.00001);
         assertEquals(0.0, t.getRPrec(), 0.00001);	// TODO Figure out a better test set
         assertEquals(0.5, t.getInfAP(), 0.00001);


### PR DESCRIPTION
Our R scripts can plot nice graphs analyzing the data, but they need .trec_eval and .sampleval files to work. Such files are normally provided by the TREC organization, but we also can generate them.

Therefore, make `AbstractEvaluator` redirect output to a file and read it later instead of collecting stream. For that to work, switch from `Runtime` to `ProcessBuilder` API.

Adapt other constructors accordingly.

This fixes #103.